### PR TITLE
Add files via upload

### DIFF
--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/CollectionSplitUtil.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/CollectionSplitUtil.java
@@ -1,0 +1,89 @@
+package com.alibaba.datax.plugin.reader.mongodbreader.util;
+
+import com.alibaba.datax.common.exception.DataXException;
+import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.datax.plugin.reader.mongodbreader.KeyConstant;
+import com.alibaba.datax.plugin.reader.mongodbreader.MongoDBReaderErrorCode;
+import com.google.common.base.Strings;
+import com.mongodb.*;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionSplitUtil {
+
+    public static List<Configuration> doSplit(
+            Configuration originalSliceConfig,int adviceNumber,MongoClient mongoClient) {
+
+        List<Configuration> confList = new ArrayList<Configuration>();
+
+        String dbName = originalSliceConfig.getString(KeyConstant.MONGO_DB_NAME);
+
+        String collectionName = originalSliceConfig.getString(KeyConstant.MONGO_COLLECTION_NAME);
+
+        if(Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(collectionName) || mongoClient == null) {
+            throw DataXException.asDataXException(MongoDBReaderErrorCode.ILLEGAL_VALUE,
+                    MongoDBReaderErrorCode.ILLEGAL_VALUE.getDescription());
+        }
+
+        String query = originalSliceConfig.getString(KeyConstant.MONGO_QUERY);
+
+        MongoDatabase db = mongoClient.getDatabase(dbName);
+        MongoCollection collection = db.getCollection(collectionName);
+
+        List<Entry> countInterval = doSplitInterval(adviceNumber, collection, query);
+        for(Entry interval : countInterval) {
+            Configuration conf = originalSliceConfig.clone();
+            conf.set(KeyConstant.SKIP_COUNT,interval.interval);
+            conf.set(KeyConstant.BATCH_SIZE,interval.batchSize);
+            confList.add(conf);
+        }
+        return confList;
+    }
+
+    private static List<Entry> doSplitInterval(int adviceNumber, MongoCollection collection, String query) {
+
+        List<Entry> intervalCountList = new ArrayList<Entry>();
+
+        long totalCount = 0;
+        if (!Strings.isNullOrEmpty(query)) {
+            String queryString[] = query.split("=");
+            //String q = "{"+queryString[0]+":{$gte:ISODate('"+queryString[1]+"')}}";//"{" + queryString[0] + ":{$gte:ISODate('" + queryString[1] + "')}}";
+            String q = "{"+queryString[0]+":{$gt:ISODate('"+queryString[1]+"'),$lte:ISODate('"+queryString[2]+"')}}";
+            System.out.println("-----count sql==="+BsonDocument.parse(q));
+            totalCount = collection.count(BsonDocument.parse(q));
+            System.out.println("-----totalCount==="+totalCount);
+        } else {
+            totalCount = collection.count();
+        }
+        if(totalCount < 0) {
+            return intervalCountList;
+        }
+        // 100 6 => 16 mod 4
+        long batchSize = totalCount/adviceNumber;
+        for(int i = 0; i < adviceNumber; i++) {
+            Entry entry = new Entry();
+            /**
+             * 这个判断确认不会丢失最后一页数据，
+             * 因为 totalCount/adviceNumber 不整除时，如果不做判断会丢失最后一页
+             */
+            if(i == (adviceNumber - 1)) {
+                entry.batchSize = batchSize + adviceNumber;
+            } else {
+                entry.batchSize = batchSize;
+            }
+            entry.interval = batchSize * i;
+            intervalCountList.add(entry);
+        }
+        return intervalCountList;
+    }
+
+}
+
+class Entry {
+    Long interval;
+    Long batchSize;
+}

--- a/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/MongoDBReader.java
+++ b/mongodbreader/src/main/java/com/alibaba/datax/plugin/reader/MongoDBReader.java
@@ -1,0 +1,287 @@
+package com.alibaba.datax.plugin.reader.mongodbreader;
+//11.27
+
+import com.alibaba.datax.common.element.*;
+import com.alibaba.datax.common.exception.DataXException;
+import com.alibaba.datax.common.plugin.RecordSender;
+import com.alibaba.datax.common.spi.Reader;
+import com.alibaba.datax.common.util.Configuration;
+import com.alibaba.datax.plugin.reader.mongodbreader.util.CollectionSplitUtil;
+import com.alibaba.datax.plugin.reader.mongodbreader.util.MongoUtil;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang.time.DateUtils;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+public class MongoDBReader extends Reader {
+
+    public static class Job extends Reader.Job {
+
+        private Configuration originalConfig = null;
+
+        private MongoClient mongoClient;
+
+        private String userName = null;
+        private String password = null;
+
+        @Override
+        public List<Configuration> split(int adviceNumber) {
+            return CollectionSplitUtil.doSplit(originalConfig,adviceNumber,mongoClient);
+        }
+
+        @Override
+            public void init() {
+            this.originalConfig = super.getPluginJobConf();
+                this.userName = originalConfig.getString(KeyConstant.MONGO_USER_NAME);
+                this.password = originalConfig.getString(KeyConstant.MONGO_USER_PASSWORD);
+                String database =  originalConfig.getString(KeyConstant.MONGO_DB_NAME);
+            if(!Strings.isNullOrEmpty(this.userName) && !Strings.isNullOrEmpty(this.password)) {
+                this.mongoClient = MongoUtil.initCredentialMongoClient(originalConfig,userName,password,database);
+            } else {
+                this.mongoClient = MongoUtil.initMongoClient(originalConfig);
+            }
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+    }
+
+
+    public static class Task extends Reader.Task {
+
+        private Configuration readerSliceConfig;
+
+        private MongoClient mongoClient;
+
+        private String userName = null;
+        private String password = null;
+
+        private String database = null;
+        private String collection = null;
+
+        private String query = null;
+
+        private JSONArray mongodbColumnMeta = null;
+        private Long batchSize = null;
+        /**
+         * 用来控制每个task取值的offset
+         */
+        private Long skipCount = null;
+        /**
+         * 每页数据的大小
+         */
+        private int pageSize = 10000;
+
+        private void log(String str){
+            System.out.println(System.currentTimeMillis()/1000+"--"+Thread.currentThread().getName()+":::"+str);
+        }
+        @Override
+        public void startRead(RecordSender recordSender) {
+            log("--------start---------");
+            if(batchSize == null ||
+                             mongoClient == null || database == null ||
+                             collection == null  || mongodbColumnMeta == null) {
+                throw DataXException.asDataXException(MongoDBReaderErrorCode.ILLEGAL_VALUE,
+                        MongoDBReaderErrorCode.ILLEGAL_VALUE.getDescription());
+            }
+            MongoDatabase db = mongoClient.getDatabase(database);
+            MongoCollection col = db.getCollection(this.collection);
+            BsonDocument sort = new BsonDocument();
+            sort.append(KeyConstant.MONGO_PRIMIARY_ID_META, new BsonInt32(1));
+            log("----mongoclient--1:host="+mongoClient.getAddress().getHost()+":port="+mongoClient.getAddress().getPort());
+            log("----mongoclient--2:"+mongoClient.getAllAddress());
+            //long pageCount = batchSize / pageSize;
+            //int modCount = (int)(batchSize % pageSize);
+            String maxId = null;
+            String minId = null;
+            Date maxDate = null;
+            Date minDate = null;
+            int num = 0;//每次条数
+            int count = 0;//总条数
+            String queryString[] = null;
+            while(true) {
+
+
+                log("----before:num = " + num + " count = " + count);
+                num = 0;
+                log("-----oldquery = " + query+",skipCount="+skipCount+",pageSize="+pageSize+",batchSize="+batchSize);
+                MongoCursor<Document> dbCursor = null;
+                if(!Strings.isNullOrEmpty(query)) {
+
+                    if(count >= 2*batchSize) {
+                        log("---------------get data error!!!!!!!!!!!----------------");
+                        break;
+                    }
+                    //query的格式为 增量字段(Date)=2017-1-26T16:00:00Z=2017-1-27T16:00:00Z.获取2017年1月27号的数据
+                    queryString = query.split("=");
+                    sort = BsonDocument.parse("{"+queryString[0]+":1}");
+                    String q = "{"+queryString[0]+":{$gte:ISODate('"+queryString[1]+"'),$lte:ISODate('"+queryString[2]+"')}}";
+                    //20171206 add
+                    if(minDate == null){
+                        q = "{" + queryString[0] + ":{$gt:ISODate('" + queryString[1] + "')," +
+                                "$lte:ISODate('" + queryString[2] +"')}}";
+                    }
+                    else{
+                        q = "{" + queryString[0] + ":{$gte:ISODate('" + DateFormatUtils.format(DateUtils.addHours(minDate,-8), DateFormatUtils.ISO_DATETIME_FORMAT.getPattern()) + 'Z'+"')," +
+                                "$lte:ISODate('" + queryString[2] +"')}}";
+                    }
+                    log("****************************minDate*************************"+minDate);
+
+                    if(!Strings.isNullOrEmpty(q)) {
+
+                        dbCursor = col.find(BsonDocument.parse(q)).sort(sort).skip(0).limit(pageSize).iterator();
+                    }
+                }
+                else {
+                    if(count >= batchSize) {
+                        break;
+                    }
+
+                    if(Strings.isNullOrEmpty(maxId)) {
+                        //取最小值
+                        if(skipCount.intValue() == 0){
+                            minId = "";
+                        }else {
+                            dbCursor = col.find().sort(sort).skip(skipCount.intValue() - 1).limit(1).iterator();
+                            while (dbCursor.hasNext()) {
+                                Document item = dbCursor.next();
+                                try {
+                                    minId = item.getString("_id").trim();
+                                }catch (Exception e){
+                                    minId = item.getObjectId("_id").toString().trim(); //org.bson.types.ObjectId cannot be cast to java.lang.String异常处理
+                                }
+
+                            }
+                        }
+                        dbCursor = col.find().sort(sort).skip(skipCount.intValue()+batchSize.intValue()-1).limit(1).iterator();
+                        while (dbCursor.hasNext()) {
+                            Document item = dbCursor.next();
+                            try {
+                                maxId = item.getString("_id").trim();
+                            }catch (Exception e) {
+                                maxId = item.getObjectId("_id").toString().trim();
+                            }
+                        }
+                    }
+                    String q = null;
+                    if(!Strings.isNullOrEmpty(minId)) {//&&!Strings.isNullOrEmpty(maxId)
+                        if(!Strings.isNullOrEmpty(maxId)) {
+                            q = "{_id:{$lte:'" + maxId + "',$gt:'" + minId + "'}}";
+                        }else {
+                            q = "{_id:{$gt:'" + minId + "'}}";
+                        }
+
+                    }else{
+                        //第一页
+                        q = "{_id:{$lte:'" + maxId + "'}}";
+//                        log("-----minId and maxId is null .maxId="+maxId+",minId="+minId);
+//                        break;
+                    }
+                    if(!Strings.isNullOrEmpty(q)) {
+                        dbCursor = col.find(BsonDocument.parse(q)).sort(sort).skip(0).limit(pageSize).iterator();
+//                            .skip(skipCount.intValue()).limit(pageSize).iterator();
+                    }
+                    log("-----q = " + q);
+
+                }
+                while (dbCursor.hasNext()) {
+                    Document item = dbCursor.next();
+                    Record record = recordSender.createRecord();
+                    Iterator columnItera = mongodbColumnMeta.iterator();
+
+                    while (columnItera.hasNext()) {
+                        JSONObject column = (JSONObject)columnItera.next();
+                        Object tempCol = item.get(column.getString(KeyConstant.COLUMN_NAME));
+                        if (tempCol == null || tempCol == "" || tempCol.equals("") || tempCol.equals(null)) {
+                            record.addColumn(new StringColumn("NULL"));
+                            continue;
+                        }
+                        if (tempCol instanceof Double) {
+                            record.addColumn(new DoubleColumn((Double) tempCol));
+                        } else if (tempCol instanceof Boolean) {
+                            record.addColumn(new BoolColumn((Boolean) tempCol));
+                        } else if (tempCol instanceof Date) {
+                            record.addColumn(new DateColumn((Date) tempCol));
+                        } else if (tempCol instanceof Integer) {
+                            record.addColumn(new LongColumn((Integer) tempCol));
+                        }else if (tempCol instanceof Long) {
+                            record.addColumn(new LongColumn((Long) tempCol));
+                        } else {
+                            if(KeyConstant.isArrayType(column.getString(KeyConstant.COLUMN_TYPE))) {
+                                String splitter = column.getString(KeyConstant.COLUMN_SPLITTER);
+                                if(Strings.isNullOrEmpty(splitter)) {
+                                    throw DataXException.asDataXException(MongoDBReaderErrorCode.ILLEGAL_VALUE,
+                                            MongoDBReaderErrorCode.ILLEGAL_VALUE.getDescription());
+                                } else {
+                                    ArrayList array = (ArrayList)tempCol;
+                                    String tempArrayStr = Joiner.on(splitter).join(array);
+                                    record.addColumn(new StringColumn(tempArrayStr.trim().replaceAll("\n","。").replaceAll("\r","。")));
+                                }
+                            } else {
+                                record.addColumn(new StringColumn(tempCol.toString().trim().replaceAll("\n","。").replaceAll("\r","。")));
+                            }
+                        }
+                    }
+                    recordSender.sendToWriter(record);
+                    try {
+                        minId = item.getString("_id").trim();
+                    }catch (Exception e) {
+                        minId = item.getObjectId("_id").toString().trim();
+                    }
+                    if(queryString!=null) {
+                        minDate = item.getDate(queryString[0]);
+                    }
+                    num++;//每条加一
+
+                }
+                count+=num;
+                skipCount += pageSize;
+                if(num<pageSize){
+                    break;
+                }
+            }
+            log("--------end---------");
+        }
+
+        @Override
+        public void init() {
+            this.readerSliceConfig = super.getPluginJobConf();
+                this.userName = readerSliceConfig.getString(KeyConstant.MONGO_USER_NAME);
+                this.password = readerSliceConfig.getString(KeyConstant.MONGO_USER_PASSWORD);
+                this.database = readerSliceConfig.getString(KeyConstant.MONGO_DB_NAME);
+            if(!Strings.isNullOrEmpty(userName) && !Strings.isNullOrEmpty(password)) {
+                mongoClient = MongoUtil.initCredentialMongoClient(readerSliceConfig,userName,password,database);
+            } else {
+                mongoClient = MongoUtil.initMongoClient(readerSliceConfig);
+            }
+            
+            this.collection = readerSliceConfig.getString(KeyConstant.MONGO_COLLECTION_NAME);
+            this.query = readerSliceConfig.getString(KeyConstant.MONGO_QUERY);
+            this.mongodbColumnMeta = JSON.parseArray(readerSliceConfig.getString(KeyConstant.MONGO_COLUMN));
+            this.batchSize = readerSliceConfig.getLong(KeyConstant.BATCH_SIZE);
+            this.skipCount = readerSliceConfig.getLong(KeyConstant.SKIP_COUNT);
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+    }
+}


### PR DESCRIPTION
1.解决了全量拉取mongodb速度慢的问题，主要在于没有以某个字段来排序和没有设置query语句，数据量过大时，每次skip都会从0开始，导致读取数据过慢。
2.增量拉取数据时可以指定某一时间段来获取数据，目前只支持设置一个并发去跑增量任务。配置文件中的配置格式示例为："query":"updateDate=2017-11-29T16:00:00Z=2017-11-30T16:00:00Z"